### PR TITLE
Send a request to delControlPermission endpoint after a control change

### DIFF
--- a/lib/core/request.ts
+++ b/lib/core/request.ts
@@ -43,6 +43,15 @@ client.interceptors.response.use((resp) => {
   });
   const out = resp.data[constants.DATA_ROOT];
 
+  // we must release control otherwise it bricks the stock app for a while
+  if (url.endsWith("rtiControl")) {
+    await client.post(url.replace("rtiControl", "delControlPermission"), {
+      [constants.DATA_ROOT]: {
+        deviceId: data.deviceId // this exists for control commands
+      }
+    }, { headers });
+  }
+
   if ('returnCd' in out) {
     const code = out.returnCd as string;
 


### PR DESCRIPTION
Previously, after setting something through this code, the LG mobile app would not be able to do anything for a few minutes, and weird errors would be returned.  This resolves this issue.

It is mentioned in issue https://github.com/sampsyo/wideq/issues/80