### PR TITLE
Add binary control support

### DIFF
--- a/lib/core/device.ts
+++ b/lib/core/device.ts
@@ -49,23 +49,11 @@ export class Device {
       if (part.startsWith("{{")) {
         part = part.substring(2, part.length-2); // chop off {{ and }}
         if (part == keyToChange) {
-          console.dir({
-              part: part,
-              result: newValue
-          });
           result.push(Number(newValue));
         } else {
-          console.dir({
-            part: part,
-            result: status.data[part]
-          });
           result.push(Number(status.data[part]));
         }
       } else { // constant
-          console.dir({
-              part: part,
-              result: Number(part)
-          });
         result.push(Number(part));
       }
     });

--- a/lib/core/session.ts
+++ b/lib/core/session.ts
@@ -81,6 +81,18 @@ export class Session {
     });
   }
 
+  public async setDeviceControlBinary(deviceId: string, data: Buffer) {
+    return this.post('rti/rtiControl', {
+      cmd: 'Control',
+      cmdOpt: 'Set',
+      value: "ControlData",
+      deviceId,
+      workId: uuid.v4(),
+      data: data.toString("base64"),
+      format: "B64"
+    });
+  }
+
   public async getDeviceConfig(deviceId: string, key: string, category = 'Config'): Promise<any> {
     const resp = await this.post('rti/rtiControl', {
       cmd: category,

--- a/lib/devices/refrigerator.ts
+++ b/lib/devices/refrigerator.ts
@@ -58,6 +58,32 @@ export class RefrigeratorDevice extends Device {
     return null;
   }
 
+  // binary based, new control method
+  public async setBinaryTempRefrigerator(status: RefrigeratorStatus, newValue: string) {
+    await this.setControlBinary(status, 'TempRefrigerator', newValue);
+  }
+
+  public async setBinaryTempFreezer(status: RefrigeratorStatus, newValue: string) {
+    await this.setControlBinary(status, 'TempFreezer', newValue);
+  }
+
+  public async setBinaryEco(status: RefrigeratorStatus, newValue: boolean) {
+    const opValue = this.model.enumValue('EcoFriendly', newValue ? OnOffEnum.ON : OnOffEnum.OFF);
+    await this.setControlBinary(status, 'EcoFriendly', opValue);
+  }
+
+  public async setBinaryIcePlus(status: RefrigeratorStatus, newValue: boolean) {
+    const opValue = this.model.enumValue('IcePlus', newValue ? OnOffEnum.ON : OnOffEnum.OFF);
+    await this.setControlBinary(status, 'IcePlus', opValue);
+  }
+
+  public async setBinaryFreshAirFilter(status: RefrigeratorStatus, newValue: FreshAirFilter) {
+    const opValue = this.model.enumValue('FreshAirFilter', newValue);
+    await this.setControlBinary(status, 'FreshAirFilter', opValue);
+  }
+
+
+  // key based, no prefix for BC
   public async setTempRefrigeratorC(temp: number) {
     // {
     //   "RETM":"{{TempRefrigerator}}",


### PR DESCRIPTION
Certain kinds of equipment use a binary string instead of key/value pairs to set data.

You can see a detailed example in sampsyo/wideq#12.  This string is dynamically generated based on the model's information, therefore, is also more natural and easier to use.

As my refrigerator uses these types of commands, I implemented methods of RefrigeratorDevice which take advantage of this control method.  The old ones are left as-is (not renamed) for backwards compatibility.  In the future, I would recommend prefixing them with "setKey" for clarity.  I plan on making a PR to NorDroN/homebridge-wideq soon which allows setting which mode to use (for different kinds of hardware).